### PR TITLE
Move boxutil out of x package

### DIFF
--- a/boxutil/doc.go
+++ b/boxutil/doc.go
@@ -1,0 +1,2 @@
+// Package boxutil provides some helpful utilities for consuming Machine Box services.
+package boxutil

--- a/boxutil/info.go
+++ b/boxutil/info.go
@@ -1,0 +1,15 @@
+package boxutil
+
+// Box represents a box client capable of returning
+// Info.
+type Box interface {
+	Info() (*Info, error)
+}
+
+// Info describes box information.
+type Info struct {
+	Name    string
+	Version int
+	Build   string
+	Status  string
+}

--- a/boxutil/status.go
+++ b/boxutil/status.go
@@ -2,13 +2,8 @@ package boxutil
 
 import (
 	"context"
-	"errors"
 	"time"
 )
-
-// ErrCanceled is returned when the context cancels or times out
-// an operation.
-var ErrCanceled = errors.New("context is done")
 
 // readyCheckInterval is the interval to wait between checking
 // the status in StatusChan.
@@ -51,7 +46,7 @@ func WaitForReady(ctx context.Context, i Box) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ErrCanceled
+			return ctx.Err()
 		case status := <-statusChan:
 			if IsReady(status) {
 				return nil

--- a/boxutil/status.go
+++ b/boxutil/status.go
@@ -3,7 +3,6 @@ package boxutil
 import (
 	"context"
 	"errors"
-	"log"
 	"time"
 )
 
@@ -20,7 +19,6 @@ var readyCheckInterval = 1 * time.Second
 // StatusChan gets a channel that periodically gets the box info
 // and sends a message whenever the status changes.
 func StatusChan(ctx context.Context, i Box) <-chan string {
-	log.Println("boxutil: DEPRECATED use github.com/machinebox/sdk-go/boxutil instead")
 	statusChan := make(chan string)
 	go func() {
 		var lastStatus string
@@ -47,7 +45,6 @@ func StatusChan(ctx context.Context, i Box) <-chan string {
 
 // WaitForReady blocks until the Box is ready.
 func WaitForReady(ctx context.Context, i Box) error {
-	log.Println("boxutil: DEPRECATED use github.com/machinebox/sdk-go/boxutil instead")
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	statusChan := StatusChan(ctx, i)
@@ -65,6 +62,5 @@ func WaitForReady(ctx context.Context, i Box) error {
 
 // IsReady gets whether the box info status is ready or not.
 func IsReady(status string) bool {
-	log.Println("boxutil: DEPRECATED use github.com/machinebox/sdk-go/boxutil instead")
 	return status == "ready"
 }

--- a/boxutil/status_test.go
+++ b/boxutil/status_test.go
@@ -1,0 +1,95 @@
+package boxutil
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/matryer/is"
+)
+
+func init() {
+	// quicker for testing
+	readyCheckInterval = 100 * time.Millisecond
+}
+
+func TestStatusChan(t *testing.T) {
+	is := is.New(t)
+
+	i := &testBox{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	status := StatusChan(ctx, i)
+	is.Equal(<-status, "starting...")
+	i.setReady()
+	is.Equal(<-status, "ready")
+	i.setError()
+	is.Equal(<-status, "unavailable")
+	i.clearError()
+	is.Equal(<-status, "ready")
+
+}
+
+func TestWaitForReady(t *testing.T) {
+	is := is.New(t)
+	i := &testBox{}
+	ctx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(300*time.Millisecond, cancel)
+	go func() {
+		i.setReady()
+	}()
+	err := WaitForReady(ctx, i)
+	is.NoErr(err)
+}
+
+func TestWaitForReadyTimeout(t *testing.T) {
+	is := is.New(t)
+	i := &testBox{}
+	ctx, cancel := context.WithCancel(context.Background())
+	time.AfterFunc(100*time.Millisecond, cancel)
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		i.setReady()
+	}()
+	err := WaitForReady(ctx, i)
+	is.Equal(err, ErrCanceled)
+}
+
+type testBox struct {
+	lock  sync.Mutex
+	ready bool
+	err   error
+}
+
+func (i *testBox) setReady() {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	i.ready = true
+}
+
+func (i *testBox) setError() {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	i.err = errors.New("cannot reach server")
+}
+
+func (i *testBox) clearError() {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	i.err = nil
+}
+
+func (i *testBox) Info() (*Info, error) {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	if i.err != nil {
+		return nil, i.err
+	}
+	if i.ready {
+		return &Info{Status: "ready"}, nil
+	}
+	return &Info{Status: "starting..."}, nil
+}

--- a/boxutil/status_test.go
+++ b/boxutil/status_test.go
@@ -55,7 +55,7 @@ func TestWaitForReadyTimeout(t *testing.T) {
 		i.setReady()
 	}()
 	err := WaitForReady(ctx, i)
-	is.Equal(err, ErrCanceled)
+	is.Equal(err, context.Canceled)
 }
 
 type testBox struct {


### PR DESCRIPTION
The old package now [prints a warning](https://github.com/machinebox/sdk-go/pull/10/files#diff-85c928e3dd101cb51c351bc8c14f99c4) if used.
  